### PR TITLE
Fixed name="" in the Create view for Events

### DIFF
--- a/FarmsAndFairytalesWebsite/Controllers/EventsController.cs
+++ b/FarmsAndFairytalesWebsite/Controllers/EventsController.cs
@@ -58,7 +58,7 @@ namespace FarmsAndFairytalesWebsite.Controllers
 		// For more details, see http://go.microsoft.com/fwlink/?LinkId=317598.
 		[HttpPost]
 		[ValidateAntiForgeryToken]
-		public async Task<IActionResult> Create([Bind("EventId,DateOfEvent,EventName,Description,PhotographerHost,ContactInfo")] Event @event, bool IsOutdoor, BookingType Type)
+		public async Task<IActionResult> Create([Bind("EventId,DateOfEvent,EventName,Description,PhotographerHost,ContactInfo")] Event @event, bool isOutdoor, BookingType Type)
 		{
 			if (ModelState.IsValid)
 			{
@@ -73,7 +73,7 @@ namespace FarmsAndFairytalesWebsite.Controllers
 				{
 					StartTime = startTime,
 					EndTime = endTime,
-					IsOutdoor = IsOutdoor,
+					IsOutdoor = isOutdoor,
 					Type = Type,
 					Photographer = user
 				};

--- a/FarmsAndFairytalesWebsite/Views/Events/Create.cshtml
+++ b/FarmsAndFairytalesWebsite/Views/Events/Create.cshtml
@@ -54,8 +54,12 @@
             <div class="form-group">
                 <label>Event Type</label>
                 <div class="radio-group">
-                    <label><input type="radio" name="EventType" value="Indoor" required /> Indoor</label>
-                    <label><input type="radio" name="EventType" value="Outdoor" required /> Outdoor</label>
+                    <label>
+                        <input type="radio" name="IsOutdoor" value="false" required /> Indoor
+                    </label>
+                    <label>
+                        <input type="radio" name="IsOutdoor" value="true" required /> Outdoor
+                    </label>
                 </div>
             </div>
 


### PR DESCRIPTION
EventType radio buttons now use name="IsOutdoor" and now it is properly passed through to the EventsController
This fixes the bug of Events always being booked to Indoor.
Closes #55 